### PR TITLE
Fix spelling for timestampMilliseconds plus javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ device id is obtained, clients can immediately start sending measurement values 
     dnwrite.setPath("Engine/Primary");
     dnwrite.setUnit("l/s");
     dnwrite.setValue(85.2f);
-    dnwrite.setTimestampMiliseconds(cal.getTimeInMillis());
+    dnwrite.setTimestampMilliseconds(cal.getTimeInMillis());
 
     WriteDataResponse writeResult = client.writeData(deviceId, dnwrite);
      
@@ -60,7 +60,7 @@ device id is obtained, clients can immediately start sending measurement values 
     for (DatanodeRead datanodeRead : datanodeReads) {
 
         for (DatanodeReadValue value : datanodeRead.getDatanodeReadValues()) {
-            System.out.println("Value=" + value.getValue() + " @" +value.getTimestampMilliSecond());
+            System.out.println("Value=" + value.getValue() + " @" +value.getTimestampMilliSeconds());
 
         }
     }

--- a/src/main/java/com/iotticket/api/v1/IOTAPIClient.java
+++ b/src/main/java/com/iotticket/api/v1/IOTAPIClient.java
@@ -222,7 +222,7 @@ public class IOTAPIClient {
 
     /**
      *
-     * @return Fetechs the user's <tt>Quota</tt> information from the server
+     * @return Fetches the user's <tt>Quota</tt> information from the server
      */
     public Quota getQuota() {
         Response res = baseTarget.path(QuotaAllResource).request().accept(JSON).get();

--- a/src/main/java/com/iotticket/api/v1/model/Datanode.java
+++ b/src/main/java/com/iotticket/api/v1/model/Datanode.java
@@ -32,7 +32,7 @@ public class Datanode extends DatanodeBase {
 
 
         @SerializedName("ts")
-        private Long timestampMiliseconds;
+        private Long timestampMilliseconds;
 
 
         public String getValue() {
@@ -99,12 +99,12 @@ public class Datanode extends DatanodeBase {
         }
 
 
-        public Long getTimestampMiliseconds() {
-            return timestampMiliseconds;
+        public Long getTimestampMilliseconds() {
+            return timestampMilliseconds;
         }
 
-        public void setTimestampMiliseconds(Long timestampMiliseconds) {
-            this.timestampMiliseconds = timestampMiliseconds;
+        public void setTimestampMilliseconds(Long timestampMilliseconds) {
+            this.timestampMilliseconds = timestampMilliseconds;
         }
     }
 
@@ -134,7 +134,7 @@ public class Datanode extends DatanodeBase {
         private String value;
 
         @SerializedName("ts")
-        private long timestampMilliSecond = UNSET;
+        private long timestampMilliSeconds = UNSET;
         private transient DataType dataType;
 
         public String getValue() {
@@ -145,12 +145,12 @@ public class Datanode extends DatanodeBase {
             this.value = value;
         }
 
-        public long getTimestampMilliSecond() {
-            return timestampMilliSecond;
+        public long getTimestampMilliSeconds() {
+            return timestampMilliSeconds;
         }
 
-        public void setTimestampMilliSecond(long timestampMilliSecond) {
-            this.timestampMilliSecond = timestampMilliSecond;
+        public void setTimestampMilliSeconds(long timestampMilliSeconds) {
+            this.timestampMilliSeconds = timestampMilliSeconds;
         }
 
         public Object getConvertedValue() {

--- a/src/test/java/DataNodeWriteReadTest.java
+++ b/src/test/java/DataNodeWriteReadTest.java
@@ -62,7 +62,7 @@ public class DataNodeWriteReadTest extends TestBase {
         assertTrue(processData.getDatanodeReads().iterator().next().getDatanodeReadValues().size() > 0);
         assertEquals(DataType.BooleanType, processData.getDatanodeReads().iterator().next().getDataType());
         assertEquals(testBooleanValue, processData.getDatanodeReads().iterator().next().getDatanodeReadValues().iterator().next().getConvertedValue());
-        assertTrue(processData.getDatanodeReads().iterator().next().getDatanodeReadValues().iterator().next().getTimestampMilliSecond() > 0L);
+        assertTrue(processData.getDatanodeReads().iterator().next().getDatanodeReadValues().iterator().next().getTimestampMilliSeconds() > 0L);
 
     }
 
@@ -123,7 +123,7 @@ public class DataNodeWriteReadTest extends TestBase {
             dnwrite.setPath(firstPath);
             dnwrite.setUnit("l/s");
             dnwrite.setValue(r.nextInt(10));
-            dnwrite.setTimestampMiliseconds(cal.getTimeInMillis());
+            dnwrite.setTimestampMilliseconds(cal.getTimeInMillis());
 
             valuesToWrite.add(dnwrite);
 
@@ -133,7 +133,7 @@ public class DataNodeWriteReadTest extends TestBase {
             dnwrite.setPath(secondPath);
             dnwrite.setUnit("l/s");
             dnwrite.setValue(10 * r.nextDouble());
-            dnwrite.setTimestampMiliseconds(cal.getTimeInMillis());
+            dnwrite.setTimestampMilliseconds(cal.getTimeInMillis());
 
             valuesToWrite.add(dnwrite);
 
@@ -184,7 +184,7 @@ public class DataNodeWriteReadTest extends TestBase {
             assertTrue(values.size() == 1);
 
             for (DatanodeReadValue value : values) {
-                long ts = value.getTimestampMilliSecond();
+                long ts = value.getTimestampMilliSeconds();
                 double val = (Double) value.getConvertedValue();
 
                 assertTrue(ts > 0);
@@ -213,7 +213,7 @@ public class DataNodeWriteReadTest extends TestBase {
             assertTrue(values.size() >= 30);
 
             for (DatanodeReadValue value : values) {
-                long ts = value.getTimestampMilliSecond();
+                long ts = value.getTimestampMilliSeconds();
                 long val = (Long) value.getConvertedValue();
 
                 assertTrue(val < 10);


### PR DESCRIPTION
- Rename DatanodeWriteValue and DatanodeReadValue time stamp to timestampMilliseconds
- Fix javadoc spelling for IOTAPIClient
