### PR TITLE
Fixes to test assertions

### DIFF
--- a/src/test/java/com/iotticket/api/v1/IOTAPIClientDeviceTest.java
+++ b/src/test/java/com/iotticket/api/v1/IOTAPIClientDeviceTest.java
@@ -11,10 +11,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -94,15 +91,15 @@ public class IOTAPIClientDeviceTest{
 						ResourceFileUtils.resourceFileToString(RESOURCE_FILE_LOCATION + "testRegisterDevice_withRequiredPropertiesOnlyRequestBody.json")))
 				.withBasicAuth(new BasicCredentials(TEST_USERNAME, TEST_PASSWORD)));
 		
-		assertEquals(result.getName(), TEST_DEVICE_NAME);
-		assertEquals(result.getManufacturer(), TEST_DEVICE_MANUFACTURER);
-		assertEquals(result.getDeviceId(), TEST_DEVICE_ID);
+		assertEquals(TEST_DEVICE_NAME, result.getName());
+		assertEquals(TEST_DEVICE_MANUFACTURER, result.getManufacturer());
+		assertEquals(TEST_DEVICE_ID, result.getDeviceId());
 		
 		// If enterprise id is not defined in request body, user's root enterprise is returned here according to documentation.
-		assertEquals(result.getEnterpriseId(), TEST_ENTERPRISE_ID);
-		assertEquals(result.getEnterpriseName(), TEST_ENTERPRISE_NAME);
-		assertEquals(result.getType(), null);
-		assertEquals(result.getDescription(), null);
+		assertEquals(TEST_ENTERPRISE_ID, result.getEnterpriseId());
+		assertEquals(TEST_ENTERPRISE_NAME, result.getEnterpriseName());
+		assertNull(result.getType());
+		assertNull(result.getDescription());
 		assertTrue(result.getAttributes().isEmpty());
 		
 	}
@@ -148,17 +145,17 @@ public class IOTAPIClientDeviceTest{
 				.withRequestBody(equalToJson(
 						ResourceFileUtils.resourceFileToString(RESOURCE_FILE_LOCATION + "testRegisterDevice_withOptionalPropertiesRequestBody.json")))
 				.withBasicAuth(new BasicCredentials(TEST_USERNAME, TEST_PASSWORD)));
-		
-		assertEquals(result.getName(), TEST_DEVICE_NAME);
-		assertEquals(result.getManufacturer(), TEST_DEVICE_MANUFACTURER);
-		assertEquals(result.getDeviceId(), TEST_DEVICE_ID);
-		assertEquals(result.getEnterpriseId(), TEST_ENTERPRISE_ID);
-		assertEquals(result.getEnterpriseName(), TEST_ENTERPRISE_NAME);
-		assertEquals(result.getType(), TEST_DEVICE_TYPE);
-		assertEquals(result.getDescription(), TEST_DEVICE_DESCRIPTION);
+
+		assertEquals(TEST_DEVICE_NAME, result.getName());
+		assertEquals(TEST_DEVICE_MANUFACTURER, result.getManufacturer());
+		assertEquals(TEST_DEVICE_ID, result.getDeviceId());
+		assertEquals(TEST_ENTERPRISE_ID, result.getEnterpriseId());
+		assertEquals(TEST_ENTERPRISE_NAME, result.getEnterpriseName());
+		assertEquals(TEST_DEVICE_TYPE, result.getType());
+		assertEquals(TEST_DEVICE_DESCRIPTION, result.getDescription());
 		
 		assertFalse(result.getAttributes().isEmpty());
-		assertEquals(result.getAttributes().size(), 2);
+		assertEquals(2, result.getAttributes().size());
 		
 	}
 	

--- a/src/test/java/com/iotticket/api/v1/IOTAPIClientEnterpriseTest.java
+++ b/src/test/java/com/iotticket/api/v1/IOTAPIClientEnterpriseTest.java
@@ -7,7 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 
@@ -142,14 +142,14 @@ public class IOTAPIClientEnterpriseTest {
 		assertEquals("https://my.iot-ticket.com/api/v1/enterprises/5678", enterprise1.getUri().toString());
 		assertEquals("Enterprise 3", enterprise1.getName());
 		assertEquals("E5678", enterprise1.getResourceId());
-		assertEquals(true, enterprise1.getHasSubEnterprises());
+		assertTrue(enterprise1.getHasSubEnterprises());
 		
 		Enterprise enterprise2 = enterprises.get(1);
 		
 		assertEquals("https://my.iot-ticket.com/api/v1/enterprises/6789", enterprise2.getUri().toString());
 		assertEquals("Enterprise 4", enterprise2.getName());
 		assertEquals("E6789", enterprise2.getResourceId());
-		assertEquals(false, enterprise2.getHasSubEnterprises());
+		assertFalse(enterprise2.getHasSubEnterprises());
 		
 	}
 	

--- a/src/test/java/com/iotticket/api/v1/IOTAPIClientStatisticalDataTest.java
+++ b/src/test/java/com/iotticket/api/v1/IOTAPIClientStatisticalDataTest.java
@@ -7,8 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -83,9 +82,9 @@ public class IOTAPIClientStatisticalDataTest {
 		assertEquals(0, value1.getCount().longValue());
 		assertEquals(0, value1.getSum().doubleValue(), 0);
 		assertEquals(1483228800000L, value1.getTimestampMilliSeconds().longValue());
-		assertTrue(null == value1.getMinimum());
-		assertTrue(null == value1.getMaximum());
-		assertTrue(null == value1.getAverage());
+		assertNull(value1.getMinimum());
+		assertNull(value1.getMaximum());
+		assertNull(value1.getAverage());
 		
 		StatisticalDataReadValue value2 = statisticalDataValues.get(1);
 		
@@ -152,9 +151,9 @@ public class IOTAPIClientStatisticalDataTest {
 		assertEquals(3, value1.getCount().longValue());
 		assertEquals(10.0, value1.getSum().doubleValue(), 0);
 		assertEquals(1546293600000L, value1.getTimestampMilliSeconds().longValue());
-		assertTrue(2.0 == value1.getMinimum());
-		assertTrue(5.0 == value1.getMaximum());
-		assertTrue(3.5 == value1.getAverage());
+		assertEquals(2.0, value1.getMinimum(), 0.0);
+		assertEquals(5.0, value1.getMaximum(), 0.0);
+		assertEquals(3.5, value1.getAverage(), 0.0);
 		
 	}
 	

--- a/src/test/java/com/iotticket/api/v1/integrationTests/DataNodeWriteReadIT.java
+++ b/src/test/java/com/iotticket/api/v1/integrationTests/DataNodeWriteReadIT.java
@@ -18,9 +18,9 @@ import static org.junit.Assert.*;
 public class DataNodeWriteReadIT extends IntegrationTestBase {
 
     private final static byte[] testByteValue = new byte[]{1, 2, 3, 4, 5, 6, 7, 9, 10};
-    public static String firstPath = "Engine/Auxillary";
-    public static String secondPath = "Engine/Main";
-    public static String numericDatanodeName = "AirVolume";
+    private static String firstPath = "Engine/Auxillary";
+    private static String secondPath = "Engine/Main";
+    private static String numericDatanodeName = "AirVolume";
     private static boolean testBooleanValue = false;
     private static String boolDatanodeName = "LightOn";
     private String byteDatanodeName = "MP3";
@@ -54,7 +54,7 @@ public class DataNodeWriteReadIT extends IntegrationTestBase {
     }
 
 
-    public void readBooleanValue() {
+    private void readBooleanValue() {
 
         DatanodeQueryCriteria criteria = new DatanodeQueryCriteria(deviceId, boolDatanodeName);
         criteria.setDeviceId(deviceId);
@@ -116,7 +116,6 @@ public class DataNodeWriteReadIT extends IntegrationTestBase {
         Random r = new Random();
 
         Collection<DatanodeWriteValue> valuesToWrite = new ArrayList<DatanodeWriteValue>();
-        valuesToWrite.size();
         for (int i = 0; i < 30; i++) {
             cal.add(Calendar.MILLISECOND, 1);
 
@@ -157,13 +156,13 @@ public class DataNodeWriteReadIT extends IntegrationTestBase {
         readFirstNumericValue();
         readSecondNumericValues();
 
-        /**Two datanodes are expected, since there are two datanodes with the name <numericDatanodeName>
+        /* Two datanodes are expected, since there are two datanodes with the name <numericDatanodeName>
          * but with different paths
          */
         DatanodeQueryCriteria crit = new DatanodeQueryCriteria(deviceId, numericDatanodeName);
         ProcessValues processValues = apiClient.readProcessData(crit);
         Collection<DatanodeRead> datanodeReads = processValues.getDatanodeReads();
-        assertTrue(datanodeReads.size() == 2);
+        assertEquals(2, datanodeReads.size());
 
 
     }
@@ -183,7 +182,7 @@ public class DataNodeWriteReadIT extends IntegrationTestBase {
 
             Collection<DatanodeReadValue> values = datanodeRead.getDatanodeReadValues();
             assertEquals(DataType.DoubleType, datanodeRead.getDataType());
-            assertTrue(values.size() == 1);
+            assertEquals(1, values.size());
 
             for (DatanodeReadValue value : values) {
                 long ts = value.getTimestampMilliSeconds();

--- a/src/test/java/com/iotticket/api/v1/integrationTests/DeviceTestIT.java
+++ b/src/test/java/com/iotticket/api/v1/integrationTests/DeviceTestIT.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
 public class DeviceTestIT extends IntegrationTestBase {
 
 
-    public static final String DEVICENAME = "DreamCar";
+    private static final String DEVICENAME = "DreamCar";
 
 
     @Test

--- a/src/test/java/com/iotticket/api/v1/integrationTests/ValidationIT.java
+++ b/src/test/java/com/iotticket/api/v1/integrationTests/ValidationIT.java
@@ -37,15 +37,15 @@ public class ValidationIT {
 
         writeValue.setValue(64.3f);
         failureNotExpected(writeValue);
-        assertEquals(writeValue.getValue(), "64.3");
+        assertEquals("64.3", writeValue.getValue());
 
 
         writeValue.setValue(true);
-        assertEquals(writeValue.getValue(), "true");
+        assertEquals("true", writeValue.getValue());
 
 
         writeValue.setValue(Integer.MIN_VALUE);
-        assertEquals(writeValue.getValue(), Integer.toString(Integer.MIN_VALUE));
+        assertEquals(Integer.toString(Integer.MIN_VALUE), writeValue.getValue());
 
 
         writeValue.setPath("1/2/3/4/5/6/7/8/9/10/11");
@@ -85,7 +85,7 @@ public class ValidationIT {
     }
 
     private static String repeatNTimes(String str, int numberOfTimes) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(numberOfTimes * str.length());
         for (int i = 0; i < numberOfTimes; i++) {
             sb.append(str);
         }

--- a/src/test/java/com/iotticket/api/v1/util/ResourceFileUtils.java
+++ b/src/test/java/com/iotticket/api/v1/util/ResourceFileUtils.java
@@ -21,11 +21,8 @@ public class ResourceFileUtils {
 		InputStream resourceFileStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
 		
 		if (resourceFileStream == null) {
-			StringBuilder message = new StringBuilder();
-			message.append("Resource file ");
-			message.append(path);
-			message.append(" not found.");
-			throw new IllegalStateException(message.toString());
+			String message = String.format("Resource file %s not found.", path);
+			throw new IllegalStateException(message);
 		}
 		
 		Scanner scanner = new Scanner(resourceFileStream);


### PR DESCRIPTION
- Turn around some assertEquals() with the expected and actual values
  in the wrong order.
- Change some unnecessarily public fields into private ones.
- Change some occurrences of assertTrue(a == 2) into assertEquals(2, a).
- Change some occurrences of assertTrue(a == null) into assertNull(a).
- Autocorrect imports.
- Fix a couple of StringBuilder cases, like giving an initial capacity,
  and using String.format() instead of a StringBuilder.